### PR TITLE
feat: use image from docker hub

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,4 +7,4 @@ services:
       - "8080:6080"
     environment:
       GEOMETRY: 1920x1080
-      VNC_PASSWORD: admin
+      VNC_PASSWORD: ${VNC_PASSWORD:-admin}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,9 @@ version: "3.3"
 
 services:
   gnome:
-    build: .
+    image: gingdev/gnome-vnc
     ports:
       - "8080:6080"
     environment:
       GEOMETRY: 1920x1080
-      VNC_PASSWORD: tranthanh
+      VNC_PASSWORD: admin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the container to use a pre-built image instead of a local build to improve reliability.
  * Made the VNC password configurable with a sensible default (falls back to "admin") for easier credential management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->